### PR TITLE
Joao suggestions

### DIFF
--- a/internal/addon/common/cleanup_resources.go
+++ b/internal/addon/common/cleanup_resources.go
@@ -1,0 +1,62 @@
+package common
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/stolostron/multicluster-observability-addon/internal/addon"
+	"k8s.io/apimachinery/pkg/api/meta"
+	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// CleanOrphanResources lists PrometheusAgents owned by CMOA and removes the ones having no existing placement.
+func CleanOrphanResources[T client.ObjectList](ctx context.Context, k8s client.Client, cmao *addonapiv1alpha1.ClusterManagementAddOn, items T) error {
+	if err := k8s.List(ctx, items, client.InNamespace(addon.InstallNamespace)); err != nil {
+		return fmt.Errorf("failed to list PrometheusAgents: %w", err)
+	}
+
+	makePlacementKey := func(namespace, name string) string {
+		return fmt.Sprintf("%s/%s", namespace, name)
+	}
+	placementsDict := map[string]struct{}{}
+	for _, placement := range cmao.Spec.InstallStrategy.Placements {
+		placementsDict[makePlacementKey(placement.Namespace, placement.Name)] = struct{}{}
+	}
+
+	// Use the Meta interface to get objects from the list
+	objs, err := meta.ExtractList(items)
+	if err != nil {
+		return fmt.Errorf("failed to extract items from list: %w", err)
+	}
+
+	for _, rawObj := range objs {
+		obj, ok := rawObj.(client.Object)
+		if !ok {
+			return fmt.Errorf("object is not a client.Object")
+		}
+
+		hasOwnerRef, err := controllerutil.HasOwnerReference(obj.GetOwnerReferences(), cmao, k8s.Scheme())
+		if err != nil {
+			return fmt.Errorf("failed to check owner references: %w", err)
+		}
+
+		if !hasOwnerRef {
+			continue
+		}
+
+		labels := obj.GetLabels()
+		placementNs := labels[addon.PlacementRefNamespaceLabelKey]
+		placementName := labels[addon.PlacementRefNameLabelKey]
+		if _, ok := placementsDict[makePlacementKey(placementNs, placementName)]; ok {
+			continue
+		}
+
+		if err := k8s.Delete(ctx, obj); err != nil {
+			return fmt.Errorf("failed to delete owned agent: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/addon/common/cleanup_resources_test.go
+++ b/internal/addon/common/cleanup_resources_test.go
@@ -1,0 +1,233 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	prometheusalpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+	"github.com/stolostron/multicluster-observability-addon/internal/addon"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func TestCleanOrphanResources(t *testing.T) {
+	// Setup common test variables
+	testNamespace := addon.InstallNamespace
+	placementName := "test-placement"
+	placementNs := testNamespace
+	cmaoName := "test-cmao"
+
+	// Create a new scheme and add the types we need
+	scheme := runtime.NewScheme()
+	require.NoError(t, addonapiv1alpha1.AddToScheme(scheme))
+	require.NoError(t, prometheusalpha1.AddToScheme(scheme))
+
+	tests := []struct {
+		name               string
+		cmao               *addonapiv1alpha1.ClusterManagementAddOn
+		cmaoOwnedResources []*prometheusalpha1.PrometheusAgent
+		extraResources     []client.Object
+		expectDeleted      map[string]bool
+	}{
+		{
+			name: "No placement exists but resources exist not owned by CMAO",
+			cmao: &addonapiv1alpha1.ClusterManagementAddOn{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: cmaoName,
+				},
+				Spec: addonapiv1alpha1.ClusterManagementAddOnSpec{
+					// No placements
+				},
+			},
+			extraResources: []client.Object{
+				&prometheusalpha1.PrometheusAgent{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "agent-1",
+						Namespace: testNamespace,
+						Labels: map[string]string{
+							addon.PlacementRefNameLabelKey:      placementName,
+							addon.PlacementRefNamespaceLabelKey: placementNs,
+						},
+						// Not owned by CMAO
+					},
+				},
+			},
+			expectDeleted: map[string]bool{
+				"agent-1": false, // Resource not owned by CMAO, shouldn't be deleted
+			},
+		},
+		{
+			name: "No placement but exist resources owned by CMAO",
+			cmao: &addonapiv1alpha1.ClusterManagementAddOn{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: cmaoName,
+				},
+				Spec: addonapiv1alpha1.ClusterManagementAddOnSpec{
+					// No placements
+				},
+			},
+			cmaoOwnedResources: []*prometheusalpha1.PrometheusAgent{
+				// Will be deleted because it's owned by CMAO but no placement
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "agent-2",
+						Namespace: testNamespace,
+						Labels: map[string]string{
+							addon.PlacementRefNameLabelKey:      placementName,
+							addon.PlacementRefNamespaceLabelKey: placementNs,
+						},
+						// Will be set as owned by CMAO in the test
+					},
+				},
+			},
+			expectDeleted: map[string]bool{
+				"agent-2": true, // Should be deleted as it's owned by CMAO and no placement exists
+			},
+		},
+		{
+			name: "Placement exists but also exists some resources not owned by CMAO",
+			cmao: &addonapiv1alpha1.ClusterManagementAddOn{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: cmaoName,
+				},
+				Spec: addonapiv1alpha1.ClusterManagementAddOnSpec{
+					InstallStrategy: addonapiv1alpha1.InstallStrategy{
+						Placements: []addonapiv1alpha1.PlacementStrategy{
+							{
+								PlacementRef: addonapiv1alpha1.PlacementRef{
+									Name:      placementName,
+									Namespace: placementNs,
+								},
+							},
+						},
+					},
+				},
+			},
+			cmaoOwnedResources: []*prometheusalpha1.PrometheusAgent{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "agent-3",
+						Namespace: testNamespace,
+						Labels: map[string]string{
+							addon.PlacementRefNameLabelKey:      placementName,
+							addon.PlacementRefNamespaceLabelKey: placementNs,
+						},
+						// Not owned by CMAO
+					},
+				},
+			},
+			extraResources: []client.Object{
+				&prometheusalpha1.PrometheusAgent{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "agent-4",
+						Namespace: testNamespace,
+						Labels: map[string]string{
+							addon.PlacementRefNameLabelKey:      placementName,
+							addon.PlacementRefNamespaceLabelKey: placementNs,
+						},
+						// Not owned by CMAO
+					},
+				},
+			},
+			expectDeleted: map[string]bool{
+				"agent-3": false, // Not owned by CMAO, shouldn't be deleted
+				"agent-4": false, // Not owned by CMAO, shouldn't be deleted
+			},
+		},
+		{
+			name: "Placement exists but also exists some resources owned by CMAO",
+			cmao: &addonapiv1alpha1.ClusterManagementAddOn{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: cmaoName,
+				},
+				Spec: addonapiv1alpha1.ClusterManagementAddOnSpec{
+					InstallStrategy: addonapiv1alpha1.InstallStrategy{
+						Placements: []addonapiv1alpha1.PlacementStrategy{
+							{
+								PlacementRef: addonapiv1alpha1.PlacementRef{
+									Name:      placementName,
+									Namespace: placementNs,
+								},
+							},
+						},
+					},
+				},
+			},
+			cmaoOwnedResources: []*prometheusalpha1.PrometheusAgent{
+				// Will not be deleted because it matches a placement
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "agent-5",
+						Namespace: testNamespace,
+						Labels: map[string]string{
+							addon.PlacementRefNameLabelKey:      placementName,
+							addon.PlacementRefNamespaceLabelKey: placementNs,
+						},
+						// Will be set as owned by CMAO in the test
+					},
+				},
+				// Will be deleted because it doesn't match any placement
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "agent-6",
+						Namespace: testNamespace,
+						Labels: map[string]string{
+							addon.PlacementRefNameLabelKey:      "other-placement",
+							addon.PlacementRefNamespaceLabelKey: placementNs,
+						},
+						// Will be set as owned by CMAO in the test
+					},
+				},
+			},
+			expectDeleted: map[string]bool{
+				"agent-5": false, // Matches placement, shouldn't be deleted
+				"agent-6": true,  // Owned by CMAO but doesn't match any placement, should be deleted
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a fresh fake client for each test case
+			existingResources := []client.Object{tc.cmao}
+			existingResources = append(existingResources, tc.extraResources...)
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingResources...).Build()
+
+			// Set up existing resources with ownership as needed
+			for _, agent := range tc.cmaoOwnedResources {
+				err := controllerutil.SetControllerReference(tc.cmao, agent, scheme)
+				require.NoError(t, err, "Failed to set controller reference")
+
+				// Create the resource in the fake client
+				err = fakeClient.Create(context.Background(), agent)
+				require.NoError(t, err, "Failed to create resource")
+			}
+
+			// Run the function under test
+			err := CleanOrphanResources(context.Background(), fakeClient, tc.cmao, &prometheusalpha1.PrometheusAgentList{})
+			require.NoError(t, err, "CleanOrphanResources should not return an error")
+
+			// Check that resources were deleted or not as expected
+			for name, shouldBeDeleted := range tc.expectDeleted {
+				agent := &prometheusalpha1.PrometheusAgent{}
+				err := fakeClient.Get(context.Background(), types.NamespacedName{
+					Name:      name,
+					Namespace: testNamespace,
+				}, agent)
+
+				if shouldBeDeleted {
+					assert.Error(t, err, "Resource %s should have been deleted", name)
+				} else {
+					assert.NoError(t, err, "Resource %s should not have been deleted", name)
+				}
+			}
+		})
+	}
+}

--- a/internal/addon/common/clustermanagementaddon.go
+++ b/internal/addon/common/clustermanagementaddon.go
@@ -1,0 +1,19 @@
+package common
+
+import (
+	"github.com/stolostron/multicluster-observability-addon/internal/addon"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+)
+
+func NewMCOAClusterManagementAddOn() *addonv1alpha1.ClusterManagementAddOn {
+	return &addonv1alpha1.ClusterManagementAddOn{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterManagementAddOn",
+			APIVersion: addonv1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: addon.Name,
+		},
+	}
+}

--- a/internal/addon/var.go
+++ b/internal/addon/var.go
@@ -44,7 +44,9 @@ const (
 	uipProbeKey       = "isAvailable"
 	uipProbePath      = ".status.conditions[?(@.type==\"Available\")].status"
 
-	DefaultStackPrefix = "default-stack-instance"
+	DefaultStackPrefix            = "default-stack-instance"
+	PlacementRefNameLabelKey      = "placement-ref-name"
+	PlacementRefNamespaceLabelKey = "placement-ref-namespace"
 )
 
 var (

--- a/internal/metrics/config/config.go
+++ b/internal/metrics/config/config.go
@@ -33,8 +33,6 @@ const (
 	AcmEtcdServiceMonitorName             = "acm-etcd"
 	AcmApiServerServiceMonitorName        = "acm-kube-apiserver"
 
-	PlacementRefNameLabelKey      = "placement-ref-name"
-	PlacementRefNamespaceLabelKey = "placement-ref-namespace"
 	RemoteWriteCfgName            = "acm-observability"
 	ScrapeClassCfgName            = "ocp-monitoring"
 )

--- a/internal/metrics/resource/agentssa.go
+++ b/internal/metrics/resource/agentssa.go
@@ -65,10 +65,10 @@ func makeConfigResourceLabels(isUWL bool, placementRef addonv1alpha1.PlacementRe
 		appName = config.UserWorkloadMetricsCollectorApp
 	}
 	return map[string]string{
-		"app.kubernetes.io/managed-by":       addon.Name,
-		"app.kubernetes.io/component":        appName,
-		config.PlacementRefNameLabelKey:      placementRef.Name,
-		config.PlacementRefNamespaceLabelKey: placementRef.Namespace,
+		"app.kubernetes.io/managed-by":      addon.Name,
+		"app.kubernetes.io/component":       appName,
+		addon.PlacementRefNameLabelKey:      placementRef.Name,
+		addon.PlacementRefNamespaceLabelKey: placementRef.Namespace,
 	}
 }
 


### PR DESCRIPTION
Two suggestions:
- Add ManagedClusters to the list of watchers (this will be nice to have on the side of logging for the Log store)
- Extract the cleanOrphanResources function outside of the metrics package (this will be used by other signals)